### PR TITLE
Add initial eslint config

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["es2015", "stage-2", "react", "flow"]
+}

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+insert_final_newline = true
+charset = utf-8
+trim_trailing_whitespace = true
+end_of_line = lf
+
+[*.{js,json}]
+indent_style = space
+indent_size = 2

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+packages/*/node_modules

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,3 @@
+{
+  "extends": "./packages/eslint-config-charts/index.js"
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,13 @@
+# Contributing
+
+## Development Workflow
+
+After cloning `ibm-design-charts`, run `yarn` to fetch its dependencies.
+
+Then, you can run several commands:
+
+- `yarn run lint` checks the code style.
+
 ## Lerna
 
 For full documentation, make sure to check out [lerna](lernajs.io).

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ibm-design-data-vis",
+  "name": "@ibm-design/charts",
   "version": "0.0.0",
   "description": "Code implementations of the IBM Design Language's data visualization guidance.",
   "repository": {
@@ -8,9 +8,21 @@
   },
   "license": "Apache-2.0",
   "scripts": {
+    "lint": "eslint packages",
     "examples": "node examples/server.js"
   },
   "devDependencies": {
+    "babel-eslint": "^7.1.1",
+    "babel-preset-es2015": "^6.18.0",
+    "babel-preset-flow": "^1.0.0",
+    "babel-preset-react": "^6.16.0",
+    "babel-preset-stage-2": "^6.18.0",
+    "eslint": "^3.13.1",
+    "eslint-plugin-babel": "^4.0.0",
+    "eslint-plugin-flowtype": "^2.29.2",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-jsx-a11y": "^3.0.2",
+    "eslint-plugin-react": "^6.9.0",
     "express": "^4.14.0",
     "lerna": "2.0.0-beta.32"
   }

--- a/packages/eslint-config-charts/README.md
+++ b/packages/eslint-config-charts/README.md
@@ -1,0 +1,3 @@
+# `eslint-config-ibm-design-charts`
+
+This is currently copied over from GHE as an opinionated `eslint` configuration.

--- a/packages/eslint-config-charts/index.js
+++ b/packages/eslint-config-charts/index.js
@@ -1,0 +1,41 @@
+
+'use strict';
+
+module.exports = {
+  parser: 'babel-eslint',
+  parserOptions: {
+    ecmaVersion: 2017,
+    sourceType: 'module',
+  },
+
+  env: {
+    // Enable these blindly because we can't make a per-file decision about this.
+    browser: true,
+    es6: true,
+    node: true,
+    jest: true,
+    jasmine: true,
+  },
+
+  globals: {
+    __DEV__: true,
+  },
+
+  extends: [
+    './rules/base',
+    './rules/best-practices',
+    './rules/es6',
+    './rules/node',
+    './rules/strict',
+    './rules/style',
+    './rules/variables',
+
+    './plugins/babel',
+    './plugins/flowtype',
+    './plugins/import',
+    './plugins/react-a11y',
+    './plugins/react',
+  ].map(require.resolve),
+
+  rules: {},
+};

--- a/packages/eslint-config-charts/package.json
+++ b/packages/eslint-config-charts/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@ibm-design/eslint-config-charts",
+  "version": "0.0.0",
+  "main": "index.js",
+  "peerDependencies": {
+    "babel-eslint": "^7.1.1",
+    "eslint": "^3.13.1",
+    "eslint-plugin-babel": "^4.0.0",
+    "eslint-plugin-flowtype": "^2.29.2",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-jsx-a11y": "^3.0.2",
+    "eslint-plugin-react": "^6.9.0"
+  }
+}

--- a/packages/eslint-config-charts/plugins/babel.js
+++ b/packages/eslint-config-charts/plugins/babel.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const OFF = 0;
+
+// eslint-plugin-babel <https://github.com/babel/eslint-plugin-babel>
+module.exports = {
+  plugins: ['babel'],
+  rules: {
+    'babel/generator-star-spacing': OFF,
+    'babel/new-cap': OFF,
+    'babel/array-bracket-spacing': OFF,
+    'babel/object-curly-spacing': OFF,
+    'babel/object-shorthand': OFF,
+    'babel/arrow-parens': OFF,
+    'babel/no-await-in-loop': OFF,
+  },
+};

--- a/packages/eslint-config-charts/plugins/flowtype.js
+++ b/packages/eslint-config-charts/plugins/flowtype.js
@@ -1,0 +1,37 @@
+'use strict';
+
+const ERROR = 2;
+
+// eslint-plugin-flowtype
+module.exports = {
+  plugins: ['flowtype'],
+  rules: {
+    // These don't actually result in warnings. Enabling them ensures they run
+    // and mark variables as used, avoiding false positives with Flow
+    // annotations.
+    'flowtype/define-flow-type': ERROR,
+    'flowtype/use-flow-type': ERROR,
+    'flowtype/object-type-delimiter': [ERROR, 'comma'],
+  },
+  globals: {
+    // Workarounds for https://github.com/babel/babel-eslint/issues/130
+    // no-undef errors incorrectly on these global flow types
+    ReactComponent: false,
+    ReactClass: false,
+    ReactElement: false,
+    ReactPropsCheckType: false,
+    ReactPropsChainableTypeChecker: false,
+    ReactPropTypes: false,
+    SyntheticEvent: false,
+    SyntheticClipboardEvent: false,
+    SyntheticCompositionEvent: false,
+    SyntheticInputEvent: false,
+    SyntheticUIEvent: false,
+    SyntheticFocusEvent: false,
+    SyntheticKeyboardEvent: false,
+    SyntheticMouseEvent: false,
+    SyntheticDragEvent: false,
+    SyntheticWheelEvent: false,
+    SyntheticTouchEvent: false,
+  },
+};

--- a/packages/eslint-config-charts/plugins/import.js
+++ b/packages/eslint-config-charts/plugins/import.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const ERROR = 2;
+
+module.exports = {
+  plugins: ['import'],
+  rules: {
+    'import/no-unresolved': ERROR,
+    'import/named': ERROR,
+    'import/no-absolute-path': ERROR,
+
+    'import/export': ERROR,
+    'import/no-named-as-default': ERROR,
+    'import/no-extraneous-dependencies': ERROR,
+    'import/no-mutable-exports': ERROR,
+
+    'import/no-duplicates': ERROR,
+    'import/extensions': ERROR,
+  },
+};

--- a/packages/eslint-config-charts/plugins/react-a11y.js
+++ b/packages/eslint-config-charts/plugins/react-a11y.js
@@ -1,0 +1,117 @@
+'use strict';
+
+const OFF = 0;
+const ERROR = 2;
+
+module.exports = {
+  plugins: [
+    'jsx-a11y',
+    'react',
+  ],
+  ecmaFeatures: {
+    jsx: true,
+  },
+  rules: {
+    // Enforce that anchors have content
+    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/anchor-has-content.md
+    'jsx-a11y/anchor-has-content': ERROR,
+
+    // Require ARIA roles to be valid and non-abstract
+    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/aria-role.md
+    'jsx-a11y/aria-role': ERROR,
+
+    // Enforce all aria-* props are valid.
+    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/aria-props.md
+    'jsx-a11y/aria-props': ERROR,
+
+    // Enforce ARIA state and property values are valid.
+    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/aria-proptypes.md
+    'jsx-a11y/aria-proptypes': ERROR,
+
+    // Enforce that elements that do not support ARIA roles, states, and
+    // properties do not have those attributes.
+    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/aria-unsupported-elements.md
+    'jsx-a11y/aria-unsupported-elements': ERROR,
+
+    // disallow href "#"
+    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/href-no-hash.md
+    'jsx-a11y/href-no-hash': ERROR,
+
+    // Require <img> to have a non-empty `alt` prop, or role="presentation"
+    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/img-has-alt.md
+    'jsx-a11y/img-has-alt': ERROR,
+
+    // Prevent img alt text from containing redundant words like "image", "picture", or "photo"
+    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/img-redundant-alt.md
+    'jsx-a11y/img-redundant-alt': ERROR,
+
+    // require that JSX labels use "htmlFor"
+    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/label-has-for.md
+    'jsx-a11y/label-has-for': ERROR,
+
+    // require that mouseover/out come with focus/blur, for keyboard-only users
+    // TODO: evaluate
+    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/mouse-events-have-key-events.md
+    'jsx-a11y/mouse-events-have-key-events': OFF,
+
+    // Prevent use of `accessKey`
+    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-access-key.md
+    'jsx-a11y/no-access-key': ERROR,
+
+    // require onBlur instead of onChange
+    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-onchange.md
+    'jsx-a11y/no-onchange': OFF,
+
+    // Enforce that elements with onClick handlers must be focusable.
+    // TODO: evaluate
+    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/onclick-has-focus.md
+    'jsx-a11y/onclick-has-focus': OFF,
+
+    // require things with onClick to have an aria role
+    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/onclick-has-role.md
+    'jsx-a11y/onclick-has-role': OFF,
+
+    // Enforce that elements with ARIA roles must have all required attributes
+    // for that role.
+    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/role-has-required-aria-props.md
+    'jsx-a11y/role-has-required-aria-props': ERROR,
+
+    // Enforce that elements with explicit or implicit roles defined contain
+    // only aria-* properties supported by that role.
+    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/role-supports-aria-props.md
+    'jsx-a11y/role-supports-aria-props': ERROR,
+
+    // Enforce tabIndex value is not greater than zero.
+    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/tabindex-no-positive.md
+    'jsx-a11y/tabindex-no-positive': ERROR,
+
+    // ensure <hX> tags have content and are not aria-hidden
+    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/heading-has-content.md
+    'jsx-a11y/heading-has-content': ERROR,
+
+    // require HTML elements to have a "lang" prop
+    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/html-has-lang.md
+    'jsx-a11y/html-has-lang': ERROR,
+
+    // require HTML element's lang prop to be valid
+    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/lang.md
+    'jsx-a11y/lang': ERROR,
+
+    // prevent marquee elements
+    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-marquee.md
+    'jsx-a11y/no-marquee': ERROR,
+
+    // only allow <th> to have the "scope" attr
+    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/scope.md
+    'jsx-a11y/scope': ERROR,
+
+    // require onClick be accompanied by onKeyUp/onKeyDown/onKeyPress
+    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/click-events-have-key-events.md
+    // TODO: enable?
+    'jsx-a11y/click-events-have-key-events': OFF,
+
+    // Enforce that DOM elements without semantic behavior not have interaction handlers
+    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-static-element-interactions.md
+    'jsx-a11y/no-static-element-interactions': ERROR,
+  },
+};

--- a/packages/eslint-config-charts/plugins/react.js
+++ b/packages/eslint-config-charts/plugins/react.js
@@ -1,0 +1,125 @@
+'use strict';
+
+const OFF = 0;
+const ERROR = 2;
+
+// eslint-plugin-react <https://github.com/yannickcr/eslint-plugin-react>
+module.exports = {
+  plugins: ['react'],
+  ecmaFeatures: {
+    jsx: true,
+  },
+  rules: {
+    // Prevent missing displayName in a React component definition
+    'react/display-name': [ERROR, {ignoreTranspilerName : false}],
+
+    // Forbid certain propTypes
+    'react/forbid-prop-types': ERROR,
+
+    // Enforce boolean attributes notation in JSX
+    'react/jsx-boolean-value': OFF,
+
+    // Validate closing bracket location in JSX
+    'react/jsx-closing-bracket-location': [ERROR, {nonEmpty: 'after-props'}],
+
+    // Enforce or disallow spaces inside of curly braces in JSX attributes
+    'react/jsx-curly-spacing': [ERROR, 'never'],
+
+    // Validate props indentation in JSX
+    'react/jsx-indent-props': [ERROR, 2],
+
+    // Validate indentation style for JSX
+    'react/jsx-indent': [ERROR, 2],
+
+    // Enforce event handler naming conventions in JSX
+    'react/jsx-handler-names': OFF,
+
+    // Validate JSX has key prop when in array or iterator
+    'react/jsx-key': ERROR,
+
+    // Limit maximum of props on a single line in JSX
+    'react/jsx-max-props-per-line': [ERROR, {maximum: 4}],
+
+    // Prevent usage of .bind() and arrow functions in JSX props
+    'react/jsx-no-bind': OFF,
+
+    'react/jsx-no-duplicate-props': [ERROR, {'ignoreCase': true}],
+
+    // Prevent usage of unwrapped JSX strings
+    'react/jsx-no-literals': OFF,
+
+    // Disallow undeclared variables in JSX
+    'react/jsx-no-undef': ERROR,
+
+    // Enforce PascalCase for user-defined JSX components
+    'react/jsx-pascal-case': ERROR,
+
+    // Enforce quote style for JSX attributes
+    'jsx-quotes': [ERROR, 'prefer-double'],
+
+    // Enforce propTypes declarations alphabetical sorting
+    'react/jsx-sort-prop-types': OFF,
+
+    // Enforce props alphabetical sorting
+    'react/jsx-sort-props': OFF,
+
+    // Prevent React to be incorrectly marked as unused
+    'react/jsx-uses-react': ERROR,
+
+    // Prevent variables used in JSX to be incorrectly marked as unused
+    'react/jsx-uses-vars': ERROR,
+
+    // Prevent usage of dangerous JSX properties
+    'react/no-danger': OFF,
+
+    // Prevent usage of setState in componentDidMount
+    'react/no-did-mount-set-state': ERROR,
+
+    // Prevent usage of setState in componentDidUpdate
+    'react/no-did-update-set-state': ERROR,
+
+    // Prevent direct mutation of this.state
+    'react/no-direct-mutation-state': ERROR,
+
+    // Prevent multiple component definition per file
+    'react/no-multi-comp': [ERROR, {ignoreStateless: true}],
+
+    // Prevent usage of setState
+    'react/no-set-state': OFF,
+
+    // Make sure we're using valid DOM elements
+    'react/no-unknown-property': ERROR,
+
+    // Prefer ES2015 Classes for creating React Components
+    'react/prefer-es6-class': ERROR,
+
+    // Ensure that we have no missing prop validations in a React Component
+    'react/prop-types': ERROR,
+
+    // Make sure that React is in the scope when JSX is used
+    'react/react-in-jsx-scope': ERROR,
+
+    // Restrict the file extension
+    'react/require-extension': OFF,
+
+    // Enforce additional closing tags when not needed
+    'react/self-closing-comp': ERROR,
+
+    // Instance-specific methods go after render, truly
+    // private (ie' internal) are last
+    'react/sort-comp': [ERROR, {
+      order: [
+        'lifecycle',
+        'render',
+        '/^_\w+$/',
+        '/^__\w+$/',
+      ],
+    }],
+
+    // Prevent missing parentheses around multilines JSX
+    'react/jsx-wrap-multilines': ERROR,
+
+    // Prevent usage of deprecated methods
+    'react/no-deprecated': ERROR,
+  },
+};

--- a/packages/eslint-config-charts/rules/base.js
+++ b/packages/eslint-config-charts/rules/base.js
@@ -1,0 +1,64 @@
+'use strict';
+
+const OFF = 0;
+const ERROR = 2;
+
+module.exports = {
+  rules: {
+    'comma-dangle': [ERROR, 'always-multiline'],
+
+    // equivalent to jshint boss
+    'no-cond-assign': OFF,
+    'no-console': ERROR,
+    // prohibits things like `while (true)`
+    'no-constant-condition': OFF,
+    // we need to be able to match these
+    'no-control-regex': OFF,
+    // equivalent to jshint debug
+    'no-debugger': ERROR,
+    // equivalent to jshint W004
+    'no-dupe-args': ERROR,
+    // syntax error in strict mode, almost certainly unintended in any case
+    'no-dupe-keys': ERROR,
+    // almost certainly a bug
+    'no-duplicate-case': ERROR,
+    // almost certainly a bug
+    'no-empty-character-class': ERROR,
+    // would warn on uncommented empty `catch (ex) {}` blocks
+    'no-empty': OFF,
+    // can cause subtle bugs in IE 8, and we shouldn't do this anyways
+    'no-ex-assign': ERROR,
+    // we shouldn't do this anyways
+    'no-extra-boolean-cast': ERROR,
+    // parens may be used to improve clarity, equivalent to jshint W068
+    'no-extra-parens': [ERROR, 'functions'],
+    // equivalent to jshint W032
+    'no-extra-semi': ERROR,
+    // a function delaration shouldn't be rewritable
+    'no-func-assign': ERROR,
+    // babel and es6 allow block-scoped functions
+    'no-inner-declarations': OFF,
+    // will cause a runtime error
+    'no-invalid-regexp': ERROR,
+    // disallow non-space or tab whitespace characters
+    'no-irregular-whitespace': ERROR,
+    // write `if (!(a in b))`, not `if (!a in b)`, equivalent to jshint W007
+    'no-negated-in-lhs': ERROR,
+    // will cause a runtime error
+    'no-obj-calls': ERROR,
+    // improves legibility
+    'no-regex-spaces': ERROR,
+    // equivalent to jshint elision
+    'no-sparse-arrays': ERROR,
+    // equivalent to jshint W027
+    'no-unreachable': ERROR,
+    // equivalent to jshint use-isnan
+    'use-isnan': ERROR,
+    // probably too noisy ATM
+    'valid-jsdoc': OFF,
+    // equivalent to jshint notypeof
+    'valid-typeof': ERROR,
+    // we already require semicolons
+    'no-unexpected-multiline': OFF,
+  },
+};

--- a/packages/eslint-config-charts/rules/best-practices.js
+++ b/packages/eslint-config-charts/rules/best-practices.js
@@ -1,0 +1,125 @@
+'use strict';
+
+const OFF = 0;
+const ERROR = 2;
+
+module.exports = {
+  rules: {
+    // probably a bug, we shouldn't actually even use this yet, because of IE8
+    'accessor-pairs': [ERROR, {setWithoutGet: true}],
+    // probably too noisy ATM
+    'block-scoped-var': OFF,
+    // cyclomatic complexity, we're too far gone
+    'complexity': OFF,
+    // require return statements to either always or never specify values
+    'consistent-return': ERROR,
+    // style guide: Always use brackets, even when optional.
+    'curly': [ERROR, 'all'],
+    // we don't do this/care about this
+    'default-case': OFF,
+    // disabled in favor of our temporary fork
+    'dot-notation': OFF,
+    // we don't do this/care about this, but probably should eventually
+    'dot-location': OFF,
+    // disabled as it's too noisy ATM
+    'eqeqeq': [OFF, 'allow-null'],
+    // we don't do this/care about this, equivalent to jshint forin
+    'guard-for-in': OFF,
+    // we have too many internal examples/tools using this
+    'no-alert': OFF,
+    // incompatible with 'use strict' equivalent to jshint noarg
+    'no-caller': ERROR,
+    // we don't care about this right now, but might later
+    'no-case-declarations': OFF,
+    // we don't do this/care about this
+    'no-div-regex': OFF,
+    // we don't do this/care about this
+    'no-else-return': OFF,
+    // avoid mistaken variables when destructuring
+    'no-empty-pattern': ERROR,
+    // see eqeqeq: we explicitly allow this, equivalent to jshint eqnull
+    'no-eq-null': OFF,
+    // equivalent to jshint evil
+    'no-eval': ERROR,
+    // should only be triggered on polyfills, which we can fix case-by-case
+    'no-extend-native': ERROR,
+    // might be a sign of a bug
+    'no-extra-bind': ERROR,
+    // equivalent to jshint W089
+    'no-fallthrough': ERROR,
+    // equivalent to jshint W008
+    'no-floating-decimal': ERROR,
+    // implicit coercion is often idiomatic
+    'no-implicit-coercion': OFF,
+    // equivalent to jshint evil/W066
+    'no-implied-eval': ERROR,
+    // will likely create more signal than noise
+    'no-invalid-this': OFF,
+    // babel should handle this fine
+    'no-iterator': OFF,
+    // Should be effectively equivalent to jshint W028 - allowing the use
+    // of labels in very specific situations. ESLint no-empty-labels was
+    // deprecated.
+    'no-labels': [ERROR, {allowLoop: true, allowSwitch: true}],
+    // lone blocks create no scope, will ignore blocks with let/const
+    'no-lone-blocks': ERROR,
+    // equivalent to jshint loopfunc
+    'no-loop-func': OFF,
+    // we surely have these, don't bother with it
+    'no-magic-numbers': OFF,
+    // we may use this for alignment in some places
+    'no-multi-spaces': OFF,
+    // equivalent to jshint multistr, consider using es6 template strings
+    'no-multi-str': ERROR,
+    // equivalent to jshint W02OFF, similar to no-extend-native
+    'no-native-reassign': [ERROR, {exceptions: ['Map', 'Set']}],
+    // equivalent to jshint evil/W054
+    'no-new-func': ERROR,
+    // don't use constructors for side-effects, equivalent to jshint nonew
+    'no-new': ERROR,
+    // very limited uses, mostly in third_party
+    'no-new-wrappers': ERROR,
+    // deprecated in ES5, but we still use it in some places
+    'no-octal-escape': ERROR,
+    // deprecated in ES5, may cause unexpected behavior
+    'no-octal': ERROR,
+    // treats function parameters as constants, probably too noisy ATM
+    'no-param-reassign': OFF,
+    // only relevant to node code
+    'no-process-env': OFF,
+    // deprecated in ES3.ERROR, equivalent to jshint proto
+    'no-proto': ERROR,
+    // jshint doesn't catch this, but this is inexcusable
+    'no-redeclare': ERROR,
+    // equivalent to jshint boss
+    'no-return-assign': OFF,
+    // equivalent to jshint scripturl
+    'no-script-url': ERROR,
+    // not in jshint, but is in jslint, and is almost certainly a mistake
+    'no-self-compare': ERROR,
+    // there are very limited valid use-cases for this
+    'no-sequences': ERROR,
+    // we're already pretty good about this, and it hides stack traces
+    'no-throw-literal': ERROR,
+    // breaks on `foo && foo.bar()` expression statements, which are common
+    'no-unused-expressions': OFF,
+    // disallow unnecessary .call() and .apply()
+    'no-useless-call': ERROR,
+    // disallow concatenating string literals
+    'no-useless-concat': ERROR,
+    // this has valid use-cases, eg. to circumvent no-unused-expressions
+    'no-void': OFF,
+    // this journey is 1% finished (allow TODO comments)
+    'no-warning-comments': OFF,
+    // equivalent to jshint withstmt
+    'no-with': OFF,
+    // require radix argument in parseInt, we do this in most places already
+    'radix': ERROR,
+    // we don't do this/care about this
+    'vars-on-top': OFF,
+    // equivalent to jshint immed
+    'wrap-iife': OFF,
+    // probably too noisy ATM
+    'yoda': OFF,
+  },
+};

--- a/packages/eslint-config-charts/rules/es6.js
+++ b/packages/eslint-config-charts/rules/es6.js
@@ -1,0 +1,41 @@
+'use strict';
+
+const OFF = 0;
+const ERROR = 2;
+
+module.exports = {
+  env: {
+    es6: true,
+  },
+  parserOptions: {
+    ecmaVersion: 6,
+    sourceType: 'module',
+  },
+  rules: {
+    'arrow-body-style': OFF,
+    'arrow-parens': OFF,
+    // tbgs finds *very few* places where we don't put spaces around =>
+    'arrow-spacing': [ERROR, {before: true, after: true}],
+    // violation of the ES6 spec, won't transform
+    'constructor-super': ERROR,
+    // https://github.com/babel/babel-eslint#known-issues
+    'generator-star-spacing': OFF,
+    'no-class-assign': ERROR,
+    'no-confusing-arrow': OFF,
+    // this is a runtime error
+    'no-const-assign': ERROR,
+    'no-dupe-class-members': ERROR,
+    // violation of the ES6 spec, won't transform, `this` is part of the TDZ
+    'no-this-before-super': ERROR,
+    // we have way too much ES3 & ES5 code
+    'no-var': OFF,
+    'object-shorthand': OFF,
+    'prefer-const': OFF,
+    'prefer-spread': OFF,
+    // we don't support/polyfill this yet
+    'prefer-reflect': OFF,
+    'prefer-template': OFF,
+    // there are legitimate use-cases for an empty generator
+    'require-yield': OFF,
+  },
+};

--- a/packages/eslint-config-charts/rules/node.js
+++ b/packages/eslint-config-charts/rules/node.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const OFF = 0;
+
+module.exports = {
+  rules: {
+    'callback-return': OFF,
+    'global-require': OFF,
+    'handle-callback-err': OFF,
+    'no-mixed-requires': OFF,
+    'no-new-require': OFF,
+    'no-path-concat': OFF,
+    'no-process-exit': OFF,
+    'no-restricted-modules': OFF,
+    'no-sync': OFF,
+  },
+};

--- a/packages/eslint-config-charts/rules/strict.js
+++ b/packages/eslint-config-charts/rules/strict.js
@@ -1,0 +1,10 @@
+'use strict';
+
+const OFF = 0;
+
+module.exports = {
+  rules: {
+    // Strict Mode <http://eslint.org/docs/rules/#strict-mode>
+    'strict': OFF,
+  },
+};

--- a/packages/eslint-config-charts/rules/style.js
+++ b/packages/eslint-config-charts/rules/style.js
@@ -1,0 +1,121 @@
+'use strict';
+
+const OFF = 0;
+const ERROR = 2;
+
+// This pattern will match these texts:
+//   var Foo = require('Foo');
+//   var Bar = require('Foo').Bar;
+//   var BarFoo = require(Bar + 'Foo');
+//   var {Bar, Foo} = require('Foo');
+//   import type {Bar, Foo} from 'Foo';
+// Also supports 'let' and 'const'.
+const variableNamePattern = String.raw`\s*[a-zA-Z_$][a-zA-Z_$\d]*\s*`;
+const maxLenIgnorePattern = String.raw`^(?:var|let|const|import type)\s+` +
+  '{?' + variableNamePattern + '(?:,' + variableNamePattern + ')*}?' +
+  String.raw`\s*(?:=\s*require\(|from)[a-zA-Z_+./"'\s\d\-]+\)?[^;\n]*[;\n]`;
+
+module.exports = {
+  rules: {
+    'array-bracket-spacing': ERROR,
+    // TODO: enable this with consensus on single line blocks
+    'block-spacing': OFF,
+    'brace-style': [ERROR, '1tbs', {allowSingleLine: true}],
+    // too noisy at the moment, and jshint didn't check it
+    'camelcase': [OFF, {properties: 'always'}],
+    'comma-spacing': [ERROR, {before: false, after: true}],
+    // jshint had laxcomma, but that was against our style guide
+    'comma-style': [ERROR, 'last'],
+    'computed-property-spacing': [ERROR, 'never'],
+    // we may use more contextually relevant names for this than self
+    'consistent-this': [OFF, 'self'],
+    // should be handled by a generic TXT linter instead
+    'eol-last': OFF,
+    'func-names': OFF,
+    // too noisy ATM
+    'func-style': [OFF, 'declaration'],
+    // no way we could enforce min/max lengths or patterns for vars
+    'id-length': OFF,
+    'id-match': OFF,
+    // we weren't enforcing this with jshint, so erroring would be too noisy
+    'indent': [ERROR, 2, {SwitchCase: 1}],
+    // we use single quotes for JS literals, double quotes for JSX literals
+    'jsx-quotes': [ERROR, 'prefer-double'],
+    // we may use extra spaces for alignment
+    'key-spacing': [OFF, {beforeColon: false, afterColon: true}],
+    'keyword-spacing': [ERROR],
+    'lines-around-comment': OFF,
+    // should be handled by a generic TXT linter instead
+    'linebreak-style': [OFF, 'unix'],
+    'max-depth': OFF,
+    'max-len': [ERROR, 120, 2,
+      {'ignorePattern': maxLenIgnorePattern},
+    ],
+    'max-nested-callbacks': OFF,
+    'max-params': OFF,
+    'max-statements': OFF,
+    // https://facebook.com/groups/995898333776940/1027358627297577
+    'new-cap': OFF,
+    // equivalent to jshint W058
+    'new-parens': ERROR,
+    'newline-after-var': OFF,
+    'no-array-constructor': ERROR,
+    'no-bitwise': ERROR,
+    'no-continue': OFF,
+    'no-inline-comments': OFF,
+    // doesn't play well with `if (__DEV__) {}`
+    'no-lonely-if': OFF,
+    // stopgap, irrelevant if we can eventually turn `indent` on to error
+    'no-mixed-spaces-and-tabs': ERROR,
+    // don't care
+    'no-multiple-empty-lines': OFF,
+    'no-negated-condition': OFF,
+    // we do this a bunch of places, and it's less bad with proper indentation
+    'no-nested-ternary': OFF,
+    // similar to FacebookWebJSLintLinter's checkPhpStyleArray
+    'no-new-object': ERROR,
+    'no-plusplus': OFF,
+    'no-restricted-syntax': OFF,
+    'no-spaced-func': ERROR,
+    'no-ternary': OFF,
+    // should be handled by a generic TXT linter instead
+    'no-trailing-spaces': OFF,
+    // we use this for private/protected identifiers
+    'no-underscore-dangle': OFF,
+    // disallow `let isYes = answer === 1 ? true : false;`
+    'no-unneeded-ternary': ERROR,
+    // too noisy ATM
+    'object-curly-spacing': OFF,
+    // makes indentation warnings clearer
+    'one-var': [ERROR, {initialized: 'never'}],
+    // prefer `x += 4` over `x = x + 4`
+    'operator-assignment': [ERROR, 'always'],
+    // equivalent to jshint laxbreak
+    'operator-linebreak': OFF,
+    'padded-blocks': OFF,
+    // probably too noisy on pre-ES5 code
+    'quote-props': [OFF, 'as-needed'],
+    'quotes': [ERROR, 'single', 'avoid-escape'],
+    'require-jsdoc': OFF,
+    'semi-spacing': [ERROR, {before: false, after: true}],
+    // equivalent to jshint asi/W032
+    'semi': [ERROR, 'always'],
+    'sort-vars': OFF,
+    // require `if () {` instead of `if (){`
+    'space-before-blocks': [ERROR, 'always'],
+    // require `function foo()` instead of `function foo ()`
+    'space-before-function-paren': [
+      ERROR,
+      {anonymous: 'never', named: 'never'},
+    ],
+    // incompatible with our legacy inline type annotations
+    'space-in-parens': [OFF, 'never'],
+    'space-infix-ops': [ERROR, {int32Hint: true}],
+    'space-unary-ops': [ERROR, {words: true, nonwords: false}],
+    // TODO: Figure out a way to do this that doesn't break typechecks
+    // or wait for https://github.com/eslint/eslint/issues/2897
+    'spaced-comment':
+      [OFF, 'always', {exceptions: ['jshint', 'jslint', 'eslint', 'global']}],
+    'wrap-regex': OFF,
+  },
+};

--- a/packages/eslint-config-charts/rules/variables.js
+++ b/packages/eslint-config-charts/rules/variables.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const OFF = 0;
+const ERROR = 2;
+
+module.exports = {
+  rules: {
+    // we don't do this/care about this
+    'init-declarations': OFF,
+    // equivalent to jshint W002, catches an IE8 bug
+    'no-catch-shadow': ERROR,
+    // equivalent to jshint W051, is a strict mode violation
+    'no-delete-var': ERROR,
+    // we should avoid labels anyways
+    'no-label-var': ERROR,
+    // redefining undefined, NaN, Infinity, arguments, and eval is bad, mkay?
+    'no-shadow-restricted-names': ERROR,
+    // a definite code-smell, but probably too noisy
+    'no-shadow': OFF,
+    // it's nice to be explicit sometimes: `let foo = undefined;`
+    'no-undef-init': ERROR,
+    // equivalent to jshint undef, turned into an error in getConfig
+    'no-undef': ERROR,
+    // using undefined is safe because we enforce no-shadow-restricted-names
+    'no-undefined': OFF,
+    // equivalent to jshint unused
+    'no-unused-vars': [ERROR, {args: 'none'}],
+    // too noisy
+    'no-use-before-define': OFF,
+  },
+};


### PR DESCRIPTION
Closes #

Copies over an opinionated `eslint` config setup from GHE in order for us to have consistent linting between projects. Includes appropriate configuration/config, as well as a simple `editorconfig` file.

#### Changelog

**New**

- `yarn run lint` Now lints the project
- `@ibm-design/eslint-config-chart` package
- `.eslintrc`, `.eslintignore`, `.babelrc` for `eslint` setup
- simple `editorconfig` file added

**Changed**

**Removed**
