### PR TITLE
Extract react-axis and react-chart into their own packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ cache:
 
 before_script:
   - yarn run lerna -- bootstrap
+  - yarn run lerna -- run build
 
 script:
   - yarn run lint

--- a/packages/charts-react-axis/README.md
+++ b/packages/charts-react-axis/README.md
@@ -1,0 +1,7 @@
+# `@ibm-design/charts-react-axis`
+
+## Usage
+
+```bash
+yarn add @ibm-design/charts-react-axis
+```

--- a/packages/charts-react-axis/package.json
+++ b/packages/charts-react-axis/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@ibm-design/charts-react-axis",
+  "version": "0.0.0",
+  "main": "lib/index.js",
+  "scripts": {
+    "build": "npm run clean && babel -d lib src",
+    "clean": "rimraf lib"
+  },
+  "license": "Apache-2.0",
+  "peerDependencies": {
+    "react": "^15.4.2"
+  },
+  "devDependencies": {
+    "@ibm-design/charts-react-test-helpers": "~0.0.0",
+    "babel-cli": "^6.18.0",
+    "react-test-renderer": "^15.4.2",
+    "rimraf": "^2.5.4"
+  }
+}

--- a/packages/charts-react-axis/package.json
+++ b/packages/charts-react-axis/package.json
@@ -13,6 +13,7 @@
   "devDependencies": {
     "@ibm-design/charts-react-test-helpers": "~0.0.0",
     "babel-cli": "^6.18.0",
+    "react": "^15.4.2",
     "react-test-renderer": "^15.4.2",
     "rimraf": "^2.5.4"
   }

--- a/packages/charts-react-axis/src/BottomAxis.js
+++ b/packages/charts-react-axis/src/BottomAxis.js
@@ -7,6 +7,7 @@ const pathStyle = {
   shapeRendering: 'crispEdges',
 };
 
+/* eslint-disable react/display-name */
 const renderTickWith = (interval) => (_, i) => {
   const offset = interval * (i + 1);
   // TODO: Label
@@ -20,6 +21,7 @@ const renderTickWith = (interval) => (_, i) => {
     />
   );
 };
+/* eslint-enable react/display-name */
 
 const BottomAxis = (props, context) => {
   const { tickCount } = props;

--- a/packages/charts-react-axis/src/BottomAxis.js
+++ b/packages/charts-react-axis/src/BottomAxis.js
@@ -1,0 +1,56 @@
+import React, { PropTypes } from 'react';
+import XTick from './XTick';
+
+const pathStyle = {
+  fill: 'none',
+  strokeWidth: 1,
+  shapeRendering: 'crispEdges',
+};
+
+const renderTickWith = (interval) => (_, i) => {
+  const offset = interval * (i + 1);
+  // TODO: Label
+  // const label = x(offset);
+
+  return (
+    <XTick
+      key={i}
+      label="Label"
+      offset={offset}
+    />
+  );
+};
+
+const BottomAxis = (props, context) => {
+  const { tickCount } = props;
+  const { chart } = context;
+
+  const path = `M0,6V0H${chart.width}V6`;
+  const interval = chart.width / tickCount;
+  const transform = `translate(0,${chart.height})`;
+
+  const renderTick = renderTickWith(interval);
+
+  return (
+    <g
+      className="axis axis--x"
+      fill="none"
+      fontSize="10"
+      fontFamily="sans-serif"
+      textAnchor="middle"
+      transform={transform}>
+      <path className="domain" d={path} stroke="#000" style={pathStyle} />
+      {Array.from(Array(tickCount - 1)).map(renderTick)}
+    </g>
+  );
+};
+
+BottomAxis.propTypes = {
+  tickCount: PropTypes.number,
+};
+
+BottomAxis.contextTypes = {
+  chart: PropTypes.object,
+};
+
+export default BottomAxis;

--- a/packages/charts-react-axis/src/LeftAxis.js
+++ b/packages/charts-react-axis/src/LeftAxis.js
@@ -1,0 +1,51 @@
+import React, { PropTypes } from 'react';
+import YTick from './YTick';
+
+const pathStyle = {
+  fill: 'none',
+  strokeWidth: 1,
+  shapeRendering: 'crispEdges',
+};
+
+const renderTickWith = (interval) => (_, i) => {
+  const offset = interval * (i + 1);
+
+  return (
+    <YTick
+      key={i}
+      label="Label"
+      offset={offset}
+    />
+  );
+};
+
+const LeftAxis = (props, context) => {
+  const { tickCount } = props;
+  const { chart } = context;
+
+  const path = `M-6,${chart.height}H0V0.5H-6`;
+  const interval = chart.height / tickCount;
+  const renderTick = renderTickWith(interval);
+
+  return (
+    <g
+      className="axis axis--y"
+      fill="none"
+      fontSize="10"
+      fontFamily="sans-serif"
+      textAnchor="end">
+      <path className="domain" d={path} stroke="#000" style={pathStyle} />
+      {Array.from(Array(tickCount - 1)).map(renderTick)}
+    </g>
+  );
+};
+
+LeftAxis.propTypes = {
+  tickCount: PropTypes.number,
+};
+
+LeftAxis.contextTypes = {
+  chart: PropTypes.object,
+};
+
+export default LeftAxis;

--- a/packages/charts-react-axis/src/LeftAxis.js
+++ b/packages/charts-react-axis/src/LeftAxis.js
@@ -7,6 +7,7 @@ const pathStyle = {
   shapeRendering: 'crispEdges',
 };
 
+/* eslint-disable react/display-name */
 const renderTickWith = (interval) => (_, i) => {
   const offset = interval * (i + 1);
 
@@ -18,6 +19,7 @@ const renderTickWith = (interval) => (_, i) => {
     />
   );
 };
+/* eslint-enable react/display-name */
 
 const LeftAxis = (props, context) => {
   const { tickCount } = props;

--- a/packages/charts-react-axis/src/XTick.js
+++ b/packages/charts-react-axis/src/XTick.js
@@ -1,0 +1,22 @@
+import React, { PropTypes } from 'react';
+
+const XTick = (props) => {
+  const { label, offset } = props;
+  const transform = `translate(${offset},0)`;
+
+  return (
+    <g className="tick" transform={transform}>
+      <line stroke="#000" x1="0.5" x2="0.5" y2="6" />
+      <text fill="#000" x="0.5" y="9" dy="0.71em">
+        {label}
+      </text>
+    </g>
+  );
+};
+
+XTick.propTypes = {
+  label: PropTypes.string.isRequired,
+  offset: PropTypes.number.isRequired,
+};
+
+export default XTick;

--- a/packages/charts-react-axis/src/YTick.js
+++ b/packages/charts-react-axis/src/YTick.js
@@ -1,0 +1,22 @@
+import React, { PropTypes } from 'react';
+
+const YTick = (props) => {
+  const { label, offset } = props;
+  const transform = `translate(0,${offset})`;
+
+  return (
+    <g className="tick" transform={transform}>
+      <line stroke="#000" x2="-6" y1="0.5" y2="0.5" />
+      <text fill="#000" x="-9" y="0.5" dy="0.32em">
+        {label}
+      </text>
+    </g>
+  );
+};
+
+YTick.propTypes = {
+  label: PropTypes.string.isRequired,
+  offset: PropTypes.number.isRequired,
+};
+
+export default YTick;

--- a/packages/charts-react-axis/src/__tests__/BottomAxis-test.js
+++ b/packages/charts-react-axis/src/__tests__/BottomAxis-test.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import { ChartProvider } from '@ibm-design/charts-react-test-helpers';
+import BottomAxis from '../BottomAxis';
+
+describe('BottomAxis Component', () => {
+  it('should render', () => {
+    const tree = renderer.create(
+      <ChartProvider>
+        <BottomAxis tickCount={5} />
+      </ChartProvider>
+    ).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/packages/charts-react-axis/src/__tests__/LeftAxis-test.js
+++ b/packages/charts-react-axis/src/__tests__/LeftAxis-test.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import { ChartProvider } from '@ibm-design/charts-react-test-helpers';
+import LeftAxis from '../LeftAxis';
+
+describe('LeftAxis Component', () => {
+  it('should render', () => {
+    const tree = renderer.create(
+      <ChartProvider>
+        <LeftAxis tickCount={5} />
+      </ChartProvider>
+    ).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/packages/charts-react-axis/src/__tests__/XTick.js
+++ b/packages/charts-react-axis/src/__tests__/XTick.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import XTick from '../XTick';
+
+describe('XTick Component', () => {
+  it('should render', () => {
+    const tree = renderer.create(
+      <XTick offset={250} label="Label" />
+    ).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/packages/charts-react-axis/src/__tests__/YTick.js
+++ b/packages/charts-react-axis/src/__tests__/YTick.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import YTick from '../YTick';
+
+describe('YTick Component', () => {
+  it('should render', () => {
+    const tree = renderer.create(
+      <YTick offset={250} label="Label" />
+    ).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/packages/charts-react-axis/src/__tests__/__snapshots__/BottomAxis-test.js.snap
+++ b/packages/charts-react-axis/src/__tests__/__snapshots__/BottomAxis-test.js.snap
@@ -1,0 +1,85 @@
+exports[`BottomAxis Component should render 1`] = `
+<g
+  className="axis axis--x"
+  fill="none"
+  fontFamily="sans-serif"
+  fontSize="10"
+  textAnchor="middle"
+  transform="translate(0,500)">
+  <path
+    className="domain"
+    d="M0,6V0H500V6"
+    stroke="#000"
+    style={
+      Object {
+        "fill": "none",
+        "shapeRendering": "crispEdges",
+        "strokeWidth": 1,
+      }
+    } />
+  <g
+    className="tick"
+    transform="translate(100,0)">
+    <line
+      stroke="#000"
+      x1="0.5"
+      x2="0.5"
+      y2="6" />
+    <text
+      dy="0.71em"
+      fill="#000"
+      x="0.5"
+      y="9">
+      Label
+    </text>
+  </g>
+  <g
+    className="tick"
+    transform="translate(200,0)">
+    <line
+      stroke="#000"
+      x1="0.5"
+      x2="0.5"
+      y2="6" />
+    <text
+      dy="0.71em"
+      fill="#000"
+      x="0.5"
+      y="9">
+      Label
+    </text>
+  </g>
+  <g
+    className="tick"
+    transform="translate(300,0)">
+    <line
+      stroke="#000"
+      x1="0.5"
+      x2="0.5"
+      y2="6" />
+    <text
+      dy="0.71em"
+      fill="#000"
+      x="0.5"
+      y="9">
+      Label
+    </text>
+  </g>
+  <g
+    className="tick"
+    transform="translate(400,0)">
+    <line
+      stroke="#000"
+      x1="0.5"
+      x2="0.5"
+      y2="6" />
+    <text
+      dy="0.71em"
+      fill="#000"
+      x="0.5"
+      y="9">
+      Label
+    </text>
+  </g>
+</g>
+`;

--- a/packages/charts-react-axis/src/__tests__/__snapshots__/LeftAxis-test.js.snap
+++ b/packages/charts-react-axis/src/__tests__/__snapshots__/LeftAxis-test.js.snap
@@ -1,0 +1,84 @@
+exports[`LeftAxis Component should render 1`] = `
+<g
+  className="axis axis--y"
+  fill="none"
+  fontFamily="sans-serif"
+  fontSize="10"
+  textAnchor="end">
+  <path
+    className="domain"
+    d="M-6,500H0V0.5H-6"
+    stroke="#000"
+    style={
+      Object {
+        "fill": "none",
+        "shapeRendering": "crispEdges",
+        "strokeWidth": 1,
+      }
+    } />
+  <g
+    className="tick"
+    transform="translate(0,100)">
+    <line
+      stroke="#000"
+      x2="-6"
+      y1="0.5"
+      y2="0.5" />
+    <text
+      dy="0.32em"
+      fill="#000"
+      x="-9"
+      y="0.5">
+      Label
+    </text>
+  </g>
+  <g
+    className="tick"
+    transform="translate(0,200)">
+    <line
+      stroke="#000"
+      x2="-6"
+      y1="0.5"
+      y2="0.5" />
+    <text
+      dy="0.32em"
+      fill="#000"
+      x="-9"
+      y="0.5">
+      Label
+    </text>
+  </g>
+  <g
+    className="tick"
+    transform="translate(0,300)">
+    <line
+      stroke="#000"
+      x2="-6"
+      y1="0.5"
+      y2="0.5" />
+    <text
+      dy="0.32em"
+      fill="#000"
+      x="-9"
+      y="0.5">
+      Label
+    </text>
+  </g>
+  <g
+    className="tick"
+    transform="translate(0,400)">
+    <line
+      stroke="#000"
+      x2="-6"
+      y1="0.5"
+      y2="0.5" />
+    <text
+      dy="0.32em"
+      fill="#000"
+      x="-9"
+      y="0.5">
+      Label
+    </text>
+  </g>
+</g>
+`;

--- a/packages/charts-react-axis/src/__tests__/__snapshots__/XTick.js.snap
+++ b/packages/charts-react-axis/src/__tests__/__snapshots__/XTick.js.snap
@@ -1,0 +1,18 @@
+exports[`XTick Component should render 1`] = `
+<g
+  className="tick"
+  transform="translate(250,0)">
+  <line
+    stroke="#000"
+    x1="0.5"
+    x2="0.5"
+    y2="6" />
+  <text
+    dy="0.71em"
+    fill="#000"
+    x="0.5"
+    y="9">
+    Label
+  </text>
+</g>
+`;

--- a/packages/charts-react-axis/src/__tests__/__snapshots__/YTick.js.snap
+++ b/packages/charts-react-axis/src/__tests__/__snapshots__/YTick.js.snap
@@ -1,0 +1,18 @@
+exports[`YTick Component should render 1`] = `
+<g
+  className="tick"
+  transform="translate(0,250)">
+  <line
+    stroke="#000"
+    x2="-6"
+    y1="0.5"
+    y2="0.5" />
+  <text
+    dy="0.32em"
+    fill="#000"
+    x="-9"
+    y="0.5">
+    Label
+  </text>
+</g>
+`;

--- a/packages/charts-react-axis/src/index.js
+++ b/packages/charts-react-axis/src/index.js
@@ -1,0 +1,4 @@
+export { default as XTick } from './XTick';
+export { default as YTick } from './YTick';
+export { default as LeftAxis } from './LeftAxis';
+export { default as BottomAxis } from './BottomAxis';

--- a/packages/charts-react-chart/README.md
+++ b/packages/charts-react-chart/README.md
@@ -1,0 +1,7 @@
+# `@ibm-design/charts-react-chart`
+
+## Usage
+
+```bash
+yarn add @ibm-design/charts-react-chart
+```

--- a/packages/charts-react-chart/package.json
+++ b/packages/charts-react-chart/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@ibm-design/charts-react-chart",
+  "version": "0.0.0",
+  "main": "lib/index.js",
+  "scripts": {
+    "build": "npm run clean && babel -d lib src",
+    "clean": "rimraf lib"
+  },
+  "license": "Apache-2.0",
+  "peerDependencies": {
+    "react": "^15.4.2"
+  },
+  "devDependencies": {
+    "babel-cli": "^6.18.0",
+    "react-test-renderer": "^15.4.2",
+    "rimraf": "^2.5.4"
+  }
+}

--- a/packages/charts-react-chart/package.json
+++ b/packages/charts-react-chart/package.json
@@ -12,6 +12,7 @@
   },
   "devDependencies": {
     "babel-cli": "^6.18.0",
+    "react": "^15.4.2",
     "react-test-renderer": "^15.4.2",
     "rimraf": "^2.5.4"
   }

--- a/packages/charts-react-chart/src/__tests__/Chart-test.js
+++ b/packages/charts-react-chart/src/__tests__/Chart-test.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import Chart from '../';
+
+describe('Chart Component', () => {
+  it('should render', () => {
+    const tree = renderer.create(
+      <Chart />
+    ).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/packages/charts-react-chart/src/__tests__/__snapshots__/Chart-test.js.snap
+++ b/packages/charts-react-chart/src/__tests__/__snapshots__/Chart-test.js.snap
@@ -1,0 +1,9 @@
+exports[`Chart Component should render 1`] = `
+<svg
+  className={undefined}
+  height={500}
+  width={960}>
+  <g
+    transform="translate(50,20)" />
+</svg>
+`;

--- a/packages/charts-react-chart/src/index.js
+++ b/packages/charts-react-chart/src/index.js
@@ -1,0 +1,68 @@
+import React, { PropTypes } from 'react';
+
+export default class Chart extends React.PureComponent {
+  // Let's place the container styling in context for layout
+  static childContextTypes = {
+    chart: PropTypes.shape({
+      width: PropTypes.number,
+      height: PropTypes.number,
+      margin: PropTypes.shape({
+        top: PropTypes.number,
+        right: PropTypes.number,
+        bottom: PropTypes.number,
+        left: PropTypes.number,
+      }),
+    }),
+  }
+
+  static propTypes = {
+    width: PropTypes.number,
+    height: PropTypes.number,
+    margin: PropTypes.shape({
+      top: PropTypes.number,
+      right: PropTypes.number,
+      bottom: PropTypes.number,
+      left: PropTypes.number,
+    }),
+  }
+
+  static defaultProps = {
+    width: 960,
+    height: 500,
+    margin: {
+      top: 20,
+      right: 20,
+      bottom: 30,
+      left: 50,
+    },
+  }
+
+  getChildContext() {
+    const { width, height, margin } = this.props;
+
+    return {
+      chart: {
+        // Calculate available width/height for child layout
+        width: width - margin.left - margin.right,
+        height: height - margin.top - margin.bottom,
+        margin,
+      },
+    };
+  }
+
+  render() {
+    const { children, className, width, height, margin } = this.props;
+    const transform = `translate(${margin.left},${margin.top})`;
+
+    return (
+      <svg
+        width={width}
+        height={height}
+        className={className}>
+        <g transform={transform}>
+          {children}
+        </g>
+      </svg>
+    );
+  }
+}

--- a/packages/charts-react-chart/src/index.js
+++ b/packages/charts-react-chart/src/index.js
@@ -1,6 +1,19 @@
 import React, { PropTypes } from 'react';
 
 export default class Chart extends React.PureComponent {
+  static propTypes = {
+    className: PropTypes.string,
+    children: PropTypes.node,
+    width: PropTypes.number,
+    height: PropTypes.number,
+    margin: PropTypes.shape({
+      top: PropTypes.number,
+      right: PropTypes.number,
+      bottom: PropTypes.number,
+      left: PropTypes.number,
+    }),
+  }
+
   // Let's place the container styling in context for layout
   static childContextTypes = {
     chart: PropTypes.shape({
@@ -12,17 +25,6 @@ export default class Chart extends React.PureComponent {
         bottom: PropTypes.number,
         left: PropTypes.number,
       }),
-    }),
-  }
-
-  static propTypes = {
-    width: PropTypes.number,
-    height: PropTypes.number,
-    margin: PropTypes.shape({
-      top: PropTypes.number,
-      right: PropTypes.number,
-      bottom: PropTypes.number,
-      left: PropTypes.number,
     }),
   }
 

--- a/packages/charts-react-line/package.json
+++ b/packages/charts-react-line/package.json
@@ -9,6 +9,8 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@ibm-design/charts-react-axis": "~0.0.0",
+    "@ibm-design/charts-react-chart": "~0.0.0",
     "d3-array": "^1.0.2",
     "d3-scale": "^1.0.4",
     "d3-shape": "^1.0.4",

--- a/packages/charts-react-line/src/Line.js
+++ b/packages/charts-react-line/src/Line.js
@@ -8,6 +8,7 @@ const path = {
 
 export default class Line extends React.PureComponent {
   static propTypes = {
+    // eslint-disable-next-line react/forbid-prop-types
     data: PropTypes.array.isRequired,
     line: PropTypes.func.isRequired,
   }

--- a/packages/charts-react-line/src/Line.js
+++ b/packages/charts-react-line/src/Line.js
@@ -1,0 +1,22 @@
+import React, { PropTypes } from 'react';
+
+const path = {
+  fill: 'none',
+  stroke: '#5392ff',
+  strokeWidth: 1.5,
+};
+
+export default class Line extends React.PureComponent {
+  static propTypes = {
+    data: PropTypes.array.isRequired,
+    line: PropTypes.func.isRequired,
+  }
+
+  render() {
+    const { data, line } = this.props;
+
+    return (
+      <path style={path} d={line(data)} />
+    );
+  }
+}

--- a/packages/charts-react-line/src/LineChart.js
+++ b/packages/charts-react-line/src/LineChart.js
@@ -4,17 +4,7 @@ import Chart from '@ibm-design/charts-react-chart';
 import { LeftAxis, BottomAxis } from '@ibm-design/charts-react-axis';
 import Line from './Line';
 
-const path = {
-  fill: 'none',
-  stroke: '#5392ff',
-  strokeWidth: 1.5,
-};
-
 export default class LineChart extends React.PureComponent {
-  static contextTypes = {
-    chart: PropTypes.any,
-  }
-
   static propTypes = {
     // eslint-disable-next-line react/forbid-prop-types
     data: PropTypes.array.isRequired,
@@ -34,6 +24,10 @@ export default class LineChart extends React.PureComponent {
     domainX: PropTypes.array,
     // eslint-disable-next-line react/forbid-prop-types
     domainY: PropTypes.array,
+  }
+
+  static contextTypes = {
+    chart: PropTypes.any,
   }
 
   static defaultProps = {

--- a/packages/charts-react-line/src/LineChart.js
+++ b/packages/charts-react-line/src/LineChart.js
@@ -1,5 +1,8 @@
 import React, { PropTypes } from 'react';
 import * as shape from 'd3-shape';
+import Chart from '@ibm-design/charts-react-chart';
+import { LeftAxis, BottomAxis } from '@ibm-design/charts-react-axis';
+import Line from './Line';
 
 const path = {
   fill: 'none',
@@ -8,6 +11,10 @@ const path = {
 };
 
 export default class LineChart extends React.PureComponent {
+  static contextTypes = {
+    chart: PropTypes.any,
+  }
+
   static propTypes = {
     // eslint-disable-next-line react/forbid-prop-types
     data: PropTypes.array.isRequired,
@@ -72,16 +79,13 @@ export default class LineChart extends React.PureComponent {
   render() {
     const { line, props } = this;
     const { data, margin, width, height } = props;
-    const containerOffset = {
-      transform: `translate(${margin.left}px, ${margin.top}px)`,
-    };
 
     return (
-      <svg width={width} height={height}>
-        <g style={containerOffset}>
-          <path style={path} d={line(data)} />
-        </g>
-      </svg>
+      <Chart width={width} height={height} margin={margin}>
+        <LeftAxis tickCount={5} />
+        <BottomAxis tickCount={5} />
+        <Line line={line} data={data} />
+      </Chart>
     );
   }
 }

--- a/packages/charts-react-line/src/__tests__/__snapshots__/LineChart-test.js.snap
+++ b/packages/charts-react-line/src/__tests__/__snapshots__/LineChart-test.js.snap
@@ -1,13 +1,175 @@
 exports[`LineChart Component should render 1`] = `
 <svg
+  className={undefined}
   height={500}
   width={960}>
   <g
-    style={
-      Object {
-        "transform": "translate(50px, 20px)",
-      }
-    }>
+    transform="translate(50,20)">
+    <g
+      className="axis axis--y"
+      fill="none"
+      fontFamily="sans-serif"
+      fontSize="10"
+      textAnchor="end">
+      <path
+        className="domain"
+        d="M-6,450H0V0.5H-6"
+        stroke="#000"
+        style={
+          Object {
+            "fill": "none",
+            "shapeRendering": "crispEdges",
+            "strokeWidth": 1,
+          }
+        } />
+      <g
+        className="tick"
+        transform="translate(0,90)">
+        <line
+          stroke="#000"
+          x2="-6"
+          y1="0.5"
+          y2="0.5" />
+        <text
+          dy="0.32em"
+          fill="#000"
+          x="-9"
+          y="0.5">
+          Label
+        </text>
+      </g>
+      <g
+        className="tick"
+        transform="translate(0,180)">
+        <line
+          stroke="#000"
+          x2="-6"
+          y1="0.5"
+          y2="0.5" />
+        <text
+          dy="0.32em"
+          fill="#000"
+          x="-9"
+          y="0.5">
+          Label
+        </text>
+      </g>
+      <g
+        className="tick"
+        transform="translate(0,270)">
+        <line
+          stroke="#000"
+          x2="-6"
+          y1="0.5"
+          y2="0.5" />
+        <text
+          dy="0.32em"
+          fill="#000"
+          x="-9"
+          y="0.5">
+          Label
+        </text>
+      </g>
+      <g
+        className="tick"
+        transform="translate(0,360)">
+        <line
+          stroke="#000"
+          x2="-6"
+          y1="0.5"
+          y2="0.5" />
+        <text
+          dy="0.32em"
+          fill="#000"
+          x="-9"
+          y="0.5">
+          Label
+        </text>
+      </g>
+    </g>
+    <g
+      className="axis axis--x"
+      fill="none"
+      fontFamily="sans-serif"
+      fontSize="10"
+      textAnchor="middle"
+      transform="translate(0,450)">
+      <path
+        className="domain"
+        d="M0,6V0H890V6"
+        stroke="#000"
+        style={
+          Object {
+            "fill": "none",
+            "shapeRendering": "crispEdges",
+            "strokeWidth": 1,
+          }
+        } />
+      <g
+        className="tick"
+        transform="translate(178,0)">
+        <line
+          stroke="#000"
+          x1="0.5"
+          x2="0.5"
+          y2="6" />
+        <text
+          dy="0.71em"
+          fill="#000"
+          x="0.5"
+          y="9">
+          Label
+        </text>
+      </g>
+      <g
+        className="tick"
+        transform="translate(356,0)">
+        <line
+          stroke="#000"
+          x1="0.5"
+          x2="0.5"
+          y2="6" />
+        <text
+          dy="0.71em"
+          fill="#000"
+          x="0.5"
+          y="9">
+          Label
+        </text>
+      </g>
+      <g
+        className="tick"
+        transform="translate(534,0)">
+        <line
+          stroke="#000"
+          x1="0.5"
+          x2="0.5"
+          y2="6" />
+        <text
+          dy="0.71em"
+          fill="#000"
+          x="0.5"
+          y="9">
+          Label
+        </text>
+      </g>
+      <g
+        className="tick"
+        transform="translate(712,0)">
+        <line
+          stroke="#000"
+          x1="0.5"
+          x2="0.5"
+          y2="6" />
+        <text
+          dy="0.71em"
+          fill="#000"
+          x="0.5"
+          y="9">
+          Label
+        </text>
+      </g>
+    </g>
     <path
       d="M0,450Z"
       style={

--- a/packages/charts-react-test-helpers/package.json
+++ b/packages/charts-react-test-helpers/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@ibm-design/charts-react-test-helpers",
+  "version": "0.0.0",
+  "main": "lib/index.js",
+  "scripts": {
+    "build": "npm run clean && babel -d lib src",
+    "clean": "rimraf lib"
+  },
+  "license": "Apache-2.0",
+  "peerDependencies": {
+    "react": "^15.4.2"
+  },
+  "devDependencies": {
+    "babel-cli": "^6.18.0",
+    "rimraf": "^2.5.4"
+  }
+}

--- a/packages/charts-react-test-helpers/package.json
+++ b/packages/charts-react-test-helpers/package.json
@@ -12,6 +12,7 @@
   },
   "devDependencies": {
     "babel-cli": "^6.18.0",
+    "react": "^15.4.2",
     "rimraf": "^2.5.4"
   }
 }

--- a/packages/charts-react-test-helpers/src/ChartProvider.js
+++ b/packages/charts-react-test-helpers/src/ChartProvider.js
@@ -7,6 +7,11 @@ import React from 'react';
  * without adding extra nodes to the snapshot output.
  */
 export default class ChartProvider extends React.PureComponent {
+  static propTypes = {
+    // eslint-disable-next-line react/forbid-prop-types
+    children: React.PropTypes.any,
+  }
+
   static childContextTypes = {
     chart: React.PropTypes.object,
   }

--- a/packages/charts-react-test-helpers/src/ChartProvider.js
+++ b/packages/charts-react-test-helpers/src/ChartProvider.js
@@ -1,0 +1,32 @@
+import React from 'react';
+
+/**
+ * It's helpful to leverage component in test scenarios where you're relying on
+ * Jest's `snapshot` feature. Since our components rely on the chart dimensions
+ * being passed in through context, use this component to provide that context
+ * without adding extra nodes to the snapshot output.
+ */
+export default class ChartProvider extends React.PureComponent {
+  static childContextTypes = {
+    chart: React.PropTypes.object,
+  }
+
+  getChildContext() {
+    return {
+      chart: {
+        width: 500,
+        height: 500,
+        margin: {
+          top: 0,
+          left: 0,
+          right: 0,
+          bottom: 0,
+        },
+      },
+    };
+  }
+
+  render() {
+    return this.props.children;
+  }
+}

--- a/packages/charts-react-test-helpers/src/index.js
+++ b/packages/charts-react-test-helpers/src/index.js
@@ -1,0 +1,1 @@
+export { default as ChartProvider } from './ChartProvider';


### PR DESCRIPTION
Closes #

We need to have some form of re-usable axes, as well as a basic `Chart` component that each visualization should (conceivably) be based off of.

These changes introduce a `Chart` component that creates the SVG node and passes chart dimensions to children through `context`.

The `Axis` package looks to generalize how to add axes to a Chart, right now we're explicitly defining `BottomAxis` and `LeftAxis`, but are looking to refactor so that the shared logic is consolidated.

In order to test each of these packages, these changes also introduce a helper package for writing tests that simply passes in a dummy chart context to the child nodes.

#### Changelog

**New**

- `charts-react-test-helpers`
- `charts-react-axis`
- `charts-react-chart`

**Changed**

- `charts-react-line` now leverages new axis and chart packages
- `package.json` now includes a `lerna` script

**Removed**
