### PR TITLE
Multiple lines with looping default stroke palette for line chart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 .env
+learn-debug.log
 node_modules
 npm-debug.log
 lib/

--- a/packages/charts-react-line/.storybook/webpack.config.js
+++ b/packages/charts-react-line/.storybook/webpack.config.js
@@ -35,6 +35,10 @@ module.exports = function (storybookBaseConfig, configType) {
       test: /\.(csv|dsv)$/,
       loader: 'dsv',
     },
+    {
+      test: /\.json$/,
+      loader: "json-loader"
+    },
   ]);
 
   return storybookBaseConfig;

--- a/packages/charts-react-line/package.json
+++ b/packages/charts-react-line/package.json
@@ -16,6 +16,7 @@
     "d3-scale": "^1.0.4",
     "d3-shape": "^1.0.4",
     "d3-time-format": "^2.0.3",
+    "ibm-design-colors": "^2.0.3",
     "react": "^15.4.2"
   },
   "devDependencies": {

--- a/packages/charts-react-line/src/Line.js
+++ b/packages/charts-react-line/src/Line.js
@@ -2,7 +2,6 @@ import React, { PropTypes } from 'react';
 
 const path = {
   fill: 'none',
-  stroke: '#000',
   strokeWidth: 1.5,
 };
 
@@ -14,9 +13,12 @@ export default class Line extends React.PureComponent {
     stroke: PropTypes.string,
   }
 
+  static defaultProps = {
+    stroke: '#000',
+  }
+
   render() {
-    const { data, line } = this.props,
-      stroke = this.props.stroke ? this.props.stroke : path.stroke;
+    const { data, line, stroke } = this.props;
 
     return (
       <path

--- a/packages/charts-react-line/src/Line.js
+++ b/packages/charts-react-line/src/Line.js
@@ -2,7 +2,7 @@ import React, { PropTypes } from 'react';
 
 const path = {
   fill: 'none',
-  stroke: '#5392ff',
+  stroke: '#000',
   strokeWidth: 1.5,
 };
 
@@ -11,13 +11,21 @@ export default class Line extends React.PureComponent {
     // eslint-disable-next-line react/forbid-prop-types
     data: PropTypes.array.isRequired,
     line: PropTypes.func.isRequired,
+    stroke: PropTypes.string,
   }
 
   render() {
-    const { data, line } = this.props;
+    const { data, line } = this.props,
+      stroke = this.props.stroke ? this.props.stroke : path.stroke;
 
     return (
-      <path style={path} d={line(data)} />
+      <path
+        style={{
+          ...path,
+          stroke: stroke,
+        }}
+        d={line(data)}
+      />
     );
   }
 }

--- a/packages/charts-react-line/src/LineChart.js
+++ b/packages/charts-react-line/src/LineChart.js
@@ -34,6 +34,7 @@ export default class LineChart extends React.PureComponent {
   }
 
   static defaultProps = {
+    lines: [],
     width: 960,
     height: 500,
     margin: {

--- a/packages/charts-react-line/src/LineChart.js
+++ b/packages/charts-react-line/src/LineChart.js
@@ -1,7 +1,7 @@
 import React, { PropTypes } from 'react';
 import * as shape from 'd3-shape';
 import Chart from '@ibm-design/charts-react-chart';
-import Colors from 'ibm-design-colors/ibm-colors.json';
+import Colors from 'ibm-design-colors/ibm-colors';
 import { LeftAxis, BottomAxis } from '@ibm-design/charts-react-axis';
 import Line from './Line';
 
@@ -52,7 +52,7 @@ export default class LineChart extends React.PureComponent {
       Colors.peach['30'],
       Colors.magenta['40'],
       Colors.indigo['40'],
-    ]
+    ],
   }
 
   componentWillMount() {
@@ -86,7 +86,7 @@ export default class LineChart extends React.PureComponent {
 
   render() {
     const { line, props } = this;
-    const { data, margin, strokes, width, height } = props;
+    const { margin, strokes, width, height } = props;
     const lines = this.props.lines.map((data, index) =>
       <Line
         line = {line}

--- a/packages/charts-react-line/src/LineChart.js
+++ b/packages/charts-react-line/src/LineChart.js
@@ -1,13 +1,14 @@
 import React, { PropTypes } from 'react';
 import * as shape from 'd3-shape';
 import Chart from '@ibm-design/charts-react-chart';
+import Colors from 'ibm-design-colors/ibm-colors.json';
 import { LeftAxis, BottomAxis } from '@ibm-design/charts-react-axis';
 import Line from './Line';
 
 export default class LineChart extends React.PureComponent {
   static propTypes = {
     // eslint-disable-next-line react/forbid-prop-types
-    data: PropTypes.array.isRequired,
+    lines: PropTypes.array.isRequired,
     width: PropTypes.number,
     height: PropTypes.number,
     margin: PropTypes.shape({
@@ -24,6 +25,8 @@ export default class LineChart extends React.PureComponent {
     domainX: PropTypes.array,
     // eslint-disable-next-line react/forbid-prop-types
     domainY: PropTypes.array,
+    // eslint-disable-next-line react/forbid-prop-types
+    strokes: PropTypes.array,
   }
 
   static contextTypes = {
@@ -39,6 +42,16 @@ export default class LineChart extends React.PureComponent {
       bottom: 30,
       left: 50,
     },
+    strokes: [
+      Colors.blue['40'],
+      Colors.aqua['20'],
+      Colors.green['30'],
+      Colors.lime['20'],
+      Colors.gold['20'],
+      Colors.peach['30'],
+      Colors.magenta['40'],
+      Colors.indigo['40'],
+    ]
   }
 
   componentWillMount() {
@@ -72,13 +85,21 @@ export default class LineChart extends React.PureComponent {
 
   render() {
     const { line, props } = this;
-    const { data, margin, width, height } = props;
+    const { data, margin, strokes, width, height } = props;
+    const lines = this.props.lines.map((data, index) =>
+      <Line
+        line = {line}
+        data = {data}
+        key={index}
+        stroke={strokes[index % strokes.length]}
+      />
+    );
 
     return (
       <Chart width={width} height={height} margin={margin}>
         <LeftAxis tickCount={5} />
         <BottomAxis tickCount={5} />
-        <Line line={line} data={data} />
+        {lines}
       </Chart>
     );
   }

--- a/packages/charts-react-line/src/LineChart.story.js
+++ b/packages/charts-react-line/src/LineChart.story.js
@@ -17,7 +17,7 @@ const data = rawData.map((d) => ({
 storiesOf('LineChart', module)
   .add('default', () => (
     <LineChart
-      data={data}
+      lines={[data]}
       width={960}
       height={500}
       margin={{

--- a/packages/charts-react-line/src/__tests__/__snapshots__/LineChart-test.js.snap
+++ b/packages/charts-react-line/src/__tests__/__snapshots__/LineChart-test.js.snap
@@ -170,15 +170,6 @@ exports[`LineChart Component should render 1`] = `
         </text>
       </g>
     </g>
-    <path
-      d="M0,450Z"
-      style={
-        Object {
-          "fill": "none",
-          "stroke": "#5392ff",
-          "strokeWidth": 1.5,
-        }
-      } />
   </g>
 </svg>
 `;


### PR DESCRIPTION
#### Changelog

**New**

- Support multiple lines on a line chart
- Alternate through the qualitative color palette by default for each line's stroke
- Added json support for line chart webpack
