### PR TITLE
Improvements to project documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,4 +27,4 @@ At the moment, we only have `./examples` to show what our desired output is. Thi
 1. `git clone https://github.com/IBM-Design/charts.git`
 2. `cd charts`
 3. `yarn install`
-4. `npm run examples`
+4. `yarn run examples`

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "description": "Code implementations of the IBM Design Language's data visualization guidance.",
   "repository": {
-    "url": "https://github.com/IBM-Design/data-vis.git",
+    "url": "https://github.com/IBM-Design/charts.git",
     "type": "git"
   },
   "license": "Apache-2.0",


### PR DESCRIPTION
Hi,

The package.json seems to still have a previous name of the repository as git reference. I updated this to the current project name.
Also, only one command in the README was specified with `npm`, while all others use `yarn`. I tested it with yarn instead and it ran well. I updated the command instruction to use yarn instead of npm.

#### Changelog

- Updated the repo link in package.json
- Made the examples command consistent with the other commands

